### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [Model Context Protocol](https://modelcontextprotocol.io) server for whois lookups.
 
+<a href="https://glama.ai/mcp/servers/cwu9e3fcwg">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/cwu9e3fcwg/badge" alt="Whois MCP server" />
+</a>
+
 **Cursor IDE Demo**
 
 https://github.com/user-attachments/assets/57a82adc-3f30-453f-aabd-7138c2e6a21d


### PR DESCRIPTION
This PR adds a badge for the [Whois MCP](https://glama.ai/mcp/servers/cwu9e3fcwg) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/cwu9e3fcwg">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/cwu9e3fcwg/badge" alt="Whois MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.